### PR TITLE
Add basic agent classes

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,10 @@
+"""Vector Money Simulation package."""
+
+from .agents import Household, Firm, Government, FinancialIntermediary
+
+__all__ = [
+    "Household",
+    "Firm",
+    "Government",
+    "FinancialIntermediary",
+]

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,13 @@
+"""Agent classes used in the vector money simulation."""
+
+from .household import Household
+from .firm import Firm
+from .government import Government
+from .financial_intermediary import FinancialIntermediary
+
+__all__ = [
+    "Household",
+    "Firm",
+    "Government",
+    "FinancialIntermediary",
+]

--- a/src/agents/financial_intermediary.py
+++ b/src/agents/financial_intermediary.py
@@ -1,0 +1,15 @@
+from mesa import Agent
+
+class FinancialIntermediary(Agent):
+    """Agent modeling a simple financial intermediary."""
+
+    def __init__(self, unique_id, model, deposits=0.0, loans=0.0, interest_rate=0.0):
+        super().__init__(unique_id, model)
+        self.deposits = deposits
+        self.loans = loans
+        self.interest_rate = interest_rate
+
+    def step(self):
+        """Accrue interest on loans and deposits."""
+        self.loans *= (1 + self.interest_rate)
+        self.deposits *= (1 + self.interest_rate * 0.5)

--- a/src/agents/firm.py
+++ b/src/agents/firm.py
@@ -1,0 +1,14 @@
+from mesa import Agent
+
+class Firm(Agent):
+    """Firm agent representing a production unit."""
+
+    def __init__(self, unique_id, model, capital=1.0, productivity=1.0):
+        super().__init__(unique_id, model)
+        self.capital = capital
+        self.productivity = productivity
+        self.output = 0.0
+
+    def step(self):
+        """Produce output based on current capital and productivity."""
+        self.output = self.capital * self.productivity

--- a/src/agents/government.py
+++ b/src/agents/government.py
@@ -1,0 +1,19 @@
+from mesa import Agent
+
+class Government(Agent):
+    """Government agent collecting taxes and providing spending."""
+
+    def __init__(self, unique_id, model, tax_rate=0.0):
+        super().__init__(unique_id, model)
+        self.tax_rate = tax_rate
+        self.revenue = 0.0
+
+    def step(self):
+        """Collect taxes from households and firms in the model."""
+        total_tax = 0.0
+        if hasattr(self.model, 'schedule'):
+            for agent in self.model.schedule.agents:
+                income = getattr(agent, 'income', 0.0)
+                profit = getattr(agent, 'output', 0.0)
+                total_tax += (income + profit) * self.tax_rate
+        self.revenue += total_tax

--- a/src/agents/household.py
+++ b/src/agents/household.py
@@ -1,0 +1,21 @@
+from mesa import Agent
+
+class Household(Agent):
+    """Household agent with income, wealth and technology choice."""
+
+    def __init__(self, unique_id, model, income=0.0, wealth=0.0, technology=None):
+        super().__init__(unique_id, model)
+        self.income = income
+        self.wealth = wealth
+        self.technology = technology
+
+    def step(self):
+        """Update the household's wealth and potentially its technology choice."""
+        # Accumulate income into wealth
+        self.wealth += self.income
+
+        # Example placeholder for technology choice update
+        technologies = getattr(self.model, "technologies", None)
+        if technologies:
+            # Simple random choice among available technologies
+            self.technology = self.random.choice(technologies)


### PR DESCRIPTION
## Summary
- implement a basic `Household` agent with income, wealth, and technology choice
- add a simple `Firm` agent for production
- create `Government` and `FinancialIntermediary` agents
- expose new agents through package init

## Testing
- `pytest -q`
- `PYTHONPATH=src python - <<'PY'
from agents import Household, Firm, Government, FinancialIntermediary
print(Household, Firm, Government, FinancialIntermediary)
PY` *(fails: ModuleNotFoundError: No module named 'mesa')*

------
https://chatgpt.com/codex/tasks/task_b_684ab9c438bc832082ff91bfa47ee68f