### PR TITLE
Add bio-physical stock models

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,10 +1,12 @@
 """Vector Money Simulation package."""
 
 from .agents import Household, Firm, Government, FinancialIntermediary
+from .biophysics import BioPhysicalStocks
 
 __all__ = [
     "Household",
     "Firm",
     "Government",
     "FinancialIntermediary",
+    "BioPhysicalStocks",
 ]

--- a/src/agents/financial_intermediary.py
+++ b/src/agents/financial_intermediary.py
@@ -3,13 +3,25 @@ from mesa import Agent
 class FinancialIntermediary(Agent):
     """Agent modeling a simple financial intermediary."""
 
-    def __init__(self, unique_id, model, deposits=0.0, loans=0.0, interest_rate=0.0):
+    def __init__(self, unique_id, model, deposits=0.0, loans=0.0, interest_rate=0.0,
+                 carbon_rate=0.1, water_rate=0.05, biomass_rate=0.0, mineral_rate=0.0):
         super().__init__(unique_id, model)
         self.deposits = deposits
         self.loans = loans
         self.interest_rate = interest_rate
+        self.carbon_rate = carbon_rate
+        self.water_rate = water_rate
+        self.biomass_rate = biomass_rate
+        self.mineral_rate = mineral_rate
 
     def step(self):
         """Accrue interest on loans and deposits."""
         self.loans *= (1 + self.interest_rate)
         self.deposits *= (1 + self.interest_rate * 0.5)
+
+        stocks = getattr(self.model, "stocks", None)
+        if stocks:
+            stocks.carbon_budget.apply(-self.carbon_rate)
+            stocks.water.apply(-self.water_rate)
+            stocks.biomass.apply(-self.biomass_rate)
+            stocks.minerals.apply(-self.mineral_rate)

--- a/src/agents/firm.py
+++ b/src/agents/firm.py
@@ -3,12 +3,24 @@ from mesa import Agent
 class Firm(Agent):
     """Firm agent representing a production unit."""
 
-    def __init__(self, unique_id, model, capital=1.0, productivity=1.0):
+    def __init__(self, unique_id, model, capital=1.0, productivity=1.0,
+                 carbon_rate=2.0, water_rate=1.0, biomass_rate=0.5, mineral_rate=0.3):
         super().__init__(unique_id, model)
         self.capital = capital
         self.productivity = productivity
         self.output = 0.0
+        self.carbon_rate = carbon_rate
+        self.water_rate = water_rate
+        self.biomass_rate = biomass_rate
+        self.mineral_rate = mineral_rate
 
     def step(self):
         """Produce output based on current capital and productivity."""
         self.output = self.capital * self.productivity
+
+        stocks = getattr(self.model, "stocks", None)
+        if stocks:
+            stocks.carbon_budget.apply(-self.carbon_rate)
+            stocks.water.apply(-self.water_rate)
+            stocks.biomass.apply(-self.biomass_rate)
+            stocks.minerals.apply(-self.mineral_rate)

--- a/src/agents/government.py
+++ b/src/agents/government.py
@@ -3,10 +3,16 @@ from mesa import Agent
 class Government(Agent):
     """Government agent collecting taxes and providing spending."""
 
-    def __init__(self, unique_id, model, tax_rate=0.0):
+    def __init__(self, unique_id, model, tax_rate=0.0,
+                 carbon_capture=0.5, water_supply=0.2,
+                 biomass_program=0.1, mineral_program=0.05):
         super().__init__(unique_id, model)
         self.tax_rate = tax_rate
         self.revenue = 0.0
+        self.carbon_capture = carbon_capture
+        self.water_supply = water_supply
+        self.biomass_program = biomass_program
+        self.mineral_program = mineral_program
 
     def step(self):
         """Collect taxes from households and firms in the model."""
@@ -17,3 +23,10 @@ class Government(Agent):
                 profit = getattr(agent, 'output', 0.0)
                 total_tax += (income + profit) * self.tax_rate
         self.revenue += total_tax
+
+        stocks = getattr(self.model, "stocks", None)
+        if stocks:
+            stocks.carbon_budget.apply(self.carbon_capture)
+            stocks.water.apply(self.water_supply)
+            stocks.biomass.apply(self.biomass_program)
+            stocks.minerals.apply(self.mineral_program)

--- a/src/agents/household.py
+++ b/src/agents/household.py
@@ -3,11 +3,16 @@ from mesa import Agent
 class Household(Agent):
     """Household agent with income, wealth and technology choice."""
 
-    def __init__(self, unique_id, model, income=0.0, wealth=0.0, technology=None):
+    def __init__(self, unique_id, model, income=0.0, wealth=0.0, technology=None,
+                 carbon_rate=1.0, water_rate=0.5, biomass_rate=0.1, mineral_rate=0.05):
         super().__init__(unique_id, model)
         self.income = income
         self.wealth = wealth
         self.technology = technology
+        self.carbon_rate = carbon_rate
+        self.water_rate = water_rate
+        self.biomass_rate = biomass_rate
+        self.mineral_rate = mineral_rate
 
     def step(self):
         """Update the household's wealth and potentially its technology choice."""
@@ -19,3 +24,11 @@ class Household(Agent):
         if technologies:
             # Simple random choice among available technologies
             self.technology = self.random.choice(technologies)
+
+        # Update bio-physical stocks if present on the model
+        stocks = getattr(self.model, "stocks", None)
+        if stocks:
+            stocks.carbon_budget.apply(-self.carbon_rate)
+            stocks.water.apply(-self.water_rate)
+            stocks.biomass.apply(-self.biomass_rate)
+            stocks.minerals.apply(-self.mineral_rate)

--- a/src/biophysics/__init__.py
+++ b/src/biophysics/__init__.py
@@ -1,0 +1,5 @@
+"""Biophysical components for the vector money simulation."""
+
+from .stocks import BioPhysicalStocks, StockModel
+
+__all__ = ["BioPhysicalStocks", "StockModel"]

--- a/src/biophysics/stocks.py
+++ b/src/biophysics/stocks.py
@@ -1,0 +1,75 @@
+"""Simple bio-physical stock models.
+
+This module defines a very small wrapper around :mod:`pysd` style stock
+behaviour.  The real :mod:`pysd` package is optional at runtime so that the
+simulation can run even when the dependency is not available.  If
+:mod:`pysd` is installed we make use of its :class:`Integ` integrator.  In
+other environments we fall back to a minimal replacement that replicates the
+same interface needed for this project.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+try:  # pragma: no cover - optional import
+    from pysd.py_backend.functions import Integ  # type: ignore
+except Exception:  # pragma: no cover - pysd may not be installed
+    class Integ:  # pragma: no cover - simple stand in
+        """Minimal replacement for ``pysd``'s ``Integ`` class."""
+
+        def __init__(self, func: Callable[[], float], initial: float = 0.0):
+            self.func = func
+            self.state = initial
+
+        def step(self, dt: float = 1.0) -> float:
+            self.state += self.func() * dt
+            return self.state
+
+@dataclass
+class StockModel:
+    """Wrapper around a stock/integrator."""
+
+    initial: float = 0.0
+    flow: Callable[[], float] = lambda: 0.0
+    integ: Integ = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.integ = Integ(self.flow, self.initial)
+
+    @property
+    def value(self) -> float:
+        return getattr(self.integ, "state", 0.0)
+
+    def step(self, dt: float = 1.0) -> None:
+        self.integ.step(dt)
+
+    def set_flow(self, flow: Callable[[], float]) -> None:
+        self.flow = flow
+        self.integ.func = flow
+
+    def apply(self, change: float) -> None:
+        """Directly modify the stock level by ``change``."""
+        self.integ.state += change
+
+
+class BioPhysicalStocks:
+    """Collection of bio-physical stocks used by the model."""
+
+    def __init__(self,
+                 carbon_budget: float = 0.0,
+                 water: float = 0.0,
+                 biomass: float = 0.0,
+                 minerals: float = 0.0) -> None:
+        self.carbon_budget = StockModel(carbon_budget)
+        self.water = StockModel(water)
+        self.biomass = StockModel(biomass)
+        self.minerals = StockModel(minerals)
+
+    def step(self) -> None:
+        """Advance all stocks one tick."""
+        self.carbon_budget.step()
+        self.water.step()
+        self.biomass.step()
+        self.minerals.step()


### PR DESCRIPTION
## Summary
- implement a `biophysics` package with stock models
- expose `BioPhysicalStocks` from the package root
- update household, firm, government and financial intermediary agents to use the stocks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684aba7e4a308320896e53609f164216