### PR TITLE
Add reinforcement learning archetypes

### DIFF
--- a/docs/prompts/add-archetypes.txt
+++ b/docs/prompts/add-archetypes.txt
@@ -1,0 +1,2 @@
+* Implement simple reinforcement learning or "LLM archetypes" shared among agents.
+* Place this logic in `src/behavior/archetypes.py`.

--- a/src/behavior/__init__.py
+++ b/src/behavior/__init__.py
@@ -1,0 +1,5 @@
+"""Behavioral archetypes package."""
+
+from .archetypes import LLMArchetype, RLArchetype
+
+__all__ = ["RLArchetype", "LLMArchetype"]

--- a/src/behavior/archetypes.py
+++ b/src/behavior/archetypes.py
@@ -1,0 +1,60 @@
+"""Common behavioural archetypes for agents."""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from typing import Callable, Dict, Hashable, List, MutableMapping
+
+
+class RLArchetype:
+    """Simple Q-learning based reinforcement learning archetype."""
+
+    def __init__(
+        self,
+        actions: List[Hashable],
+        learning_rate: float = 0.1,
+        discount: float = 0.95,
+        epsilon: float = 0.1,
+    ) -> None:
+        self.actions = actions
+        self.learning_rate = learning_rate
+        self.discount = discount
+        self.epsilon = epsilon
+        self.q_table: MutableMapping[Hashable, MutableMapping[Hashable, float]] = (
+            defaultdict(lambda: defaultdict(float))
+        )
+
+    def choose_action(self, state: Hashable) -> Hashable:
+        """Return an action using an \epsilon-greedy policy."""
+        if random.random() < self.epsilon:
+            return random.choice(self.actions)
+        q_values = self.q_table[state]
+        if not q_values:
+            return random.choice(self.actions)
+        return max(self.actions, key=lambda a: q_values[a])
+
+    def update(
+        self, state: Hashable, action: Hashable, reward: float, next_state: Hashable
+    ) -> None:
+        """Update the Q-table from an experience."""
+        current = self.q_table[state][action]
+        next_values = self.q_table[next_state]
+        next_max = max(next_values.values()) if next_values else 0.0
+        target = reward + self.discount * next_max
+        self.q_table[state][action] = current + self.learning_rate * (target - current)
+
+
+class LLMArchetype:
+    """Lightweight archetype wrapper around a language model function."""
+
+    def __init__(
+        self, prompt: str, call_func: Callable[[str], str] | None = None
+    ) -> None:
+        self.prompt = prompt
+        self.call_func = call_func or (lambda x: "")
+
+    def generate(self, user_input: str) -> str:
+        """Generate text using ``call_func``."""
+        full_prompt = f"{self.prompt}\n{user_input}"
+        return self.call_func(full_prompt)

--- a/tests/test_archetypes.py
+++ b/tests/test_archetypes.py
@@ -1,0 +1,16 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+sys.modules.setdefault("mesa", types.ModuleType("mesa")).Agent = object
+
+from src.behavior.archetypes import RLArchetype
+
+
+def test_rl_archetype_updates_q_values():
+    arch = RLArchetype(actions=["a", "b"], learning_rate=1.0, discount=0.0, epsilon=0.0)
+    arch.update("s1", "a", reward=1.0, next_state="s2")
+    assert arch.q_table["s1"]["a"] == 1.0
+    assert arch.choose_action("s1") == "a"


### PR DESCRIPTION
## Summary
- introduce `RLArchetype` Q-learning helper and `LLMArchetype`
- export the archetypes via new behavior package
- test RLArchetype learning behaviour
- log prompt for archetypes work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684abdce605083208860e8e8d78832f5