### PR TITLE
Add data loading utilities

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,9 @@ Project documentation.
 The ``Market`` class provides a simple trading system that links economic
 agents with the bio-physical stocks.  Prices automatically adjust whenever a
 stock falls below its ecological limit, modelling scarcity effects.
+
+## Data
+
+The ``data`` package loads input-output tables and ecological inventories using pandas.
+It also provides ``normalise_per_capita`` to express indicators per person for
+Doughnut Economics style analysis.

--- a/docs/prompts/add-data-normalisation.txt
+++ b/docs/prompts/add-data-normalisation.txt
@@ -1,0 +1,2 @@
+* Add scripts under `src/data/` to read input-output tables (e.g., EXIOBASE) and ecological inventories.
+* Normalise data to per-capita indicators consistent with Doughnut Economics.

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,6 @@
+"""Data loading and normalisation utilities."""
+
+from .io import read_inventory, read_io_table
+from .normalise import normalise_per_capita
+
+__all__ = ["read_io_table", "read_inventory", "normalise_per_capita"]

--- a/src/data/io.py
+++ b/src/data/io.py
@@ -1,0 +1,24 @@
+"""Functions to load input-output tables and ecological inventories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def _read_file(path: str | Path) -> pd.DataFrame:
+    path = Path(path)
+    if path.suffix in {".xlsx", ".xls"}:
+        return pd.read_excel(path)
+    return pd.read_csv(path)
+
+
+def read_io_table(path: str | Path) -> pd.DataFrame:
+    """Return an input-output table located at ``path``."""
+    return _read_file(path)
+
+
+def read_inventory(path: str | Path) -> pd.DataFrame:
+    """Return an ecological inventory located at ``path``."""
+    return _read_file(path)

--- a/src/data/normalise.py
+++ b/src/data/normalise.py
@@ -1,0 +1,20 @@
+"""Data normalisation helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+
+
+def normalise_per_capita(
+    data: pd.DataFrame, population: float, columns: Iterable[str] | None = None
+) -> pd.DataFrame:
+    """Return a per-capita normalised copy of ``data``."""
+    if population == 0:
+        raise ValueError("population must be non-zero")
+
+    df = data.copy()
+    cols = list(columns) if columns is not None else df.select_dtypes("number").columns
+    df[cols] = df[cols].div(population)
+    return df

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from src.data.io import read_inventory, read_io_table
+from src.data.normalise import normalise_per_capita
+
+
+def test_read_io_and_inventory(tmp_path):
+    csv = tmp_path / "table.csv"
+    csv.write_text("a,b\n1,2\n3,4\n")
+    df_io = read_io_table(csv)
+    df_inv = read_inventory(csv)
+    assert df_io.equals(df_inv)
+    assert df_io.shape == (2, 2)
+
+
+def test_normalise_per_capita():
+    df = pd.DataFrame({"a": [10, 20], "b": [30, 40]})
+    result = normalise_per_capita(df, population=10)
+    assert result.iloc[0, 0] == 1
+    assert result.iloc[1, 1] == 4


### PR DESCRIPTION
## Summary
- add `data` package for loading IO tables and ecological inventories
- implement per-capita normalisation helper
- document data utilities
- test data loading and normalisation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684ac1c9f2088320a6b7edbb439a64b5